### PR TITLE
Final changes for relicensing to MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solidity-parser-antlr",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "A Solidity parser built from a robust ANTLR 4 grammar",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Hi @federicobond,

I'm really thankful you relicensed this lib! but it looks like you forgot to update `solidity-antlr4` git submodule, and to publish a new version to npm. So here are the changes needed to do that :)

Note that while relicensing a project is a big change, and according to `semver` may need a major version bump, moving from GLPv3 to MIT is backwards compatible, so I just changed the patch version.