### PR TITLE
Don't print lexer errors to stderr

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,11 +29,16 @@ function parse (input, options) {
   options = options || {}
 
   const chars = antlr4.CharStreams.fromString(input)
+
+  const listener = new ErrorListener()
+
   const lexer = new SolidityLexer(chars)
+  lexer.removeErrorListeners()
+  lexer.addErrorListener(listener)
+
   const tokens = new antlr4.CommonTokenStream(lexer)
 
   const parser = new SolidityParser(tokens)
-  const listener = new ErrorListener()
 
   parser.removeErrorListeners()
   parser.addErrorListener(listener)

--- a/test/index.js
+++ b/test/index.js
@@ -1351,4 +1351,16 @@ describe("#visit", () => {
     })
   })
 
+  it.only("shouldn't print anything if the lexer fails", () => {
+    const originalConsoleError = console.error
+    let called = false
+    console.error = () => called = true
+
+    var ast = parser.parse('"', {tolerant: true})
+
+    console.error = originalConsoleError
+
+    assert.isFalse(called, "Should not call console.error on lexer errors")
+  });
+
 })

--- a/test/index.js
+++ b/test/index.js
@@ -1351,7 +1351,7 @@ describe("#visit", () => {
     })
   })
 
-  it.only("shouldn't print anything if the lexer fails", () => {
+  it("shouldn't print anything if the lexer fails", () => {
     const originalConsoleError = console.error
     let called = false
     console.error = () => called = true


### PR DESCRIPTION
Hi Fede, 

This is a quick PR that avoid printing lexing errors to stderr. I removed the lexer's default error listener, and use the same one that the parser's instead.