### PR TITLE
Add line and column to error message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,8 @@ const ErrorListener = require('./ErrorListener')
 const { buildTokenList } = require('./tokens')
 
 function ParserError(args) {
-  this.message = args.errors[0].message
+  const { message, line, column } = args.errors[0]
+  this.message = `${message} (${line}:${column})`
   this.errors = args.errors
 
   if (Error.captureStackTrace) {


### PR DESCRIPTION
Instead of having this error message:

```
ParserError: missing '(' at 'uint'
```

show this:

```
ParserError: missing '(' at 'uint' (5:33)
```

I think this can make a huge difference when the parse error is not caught and ends up being shown to the user.