### PR TITLE
Fix `parameters` type on EventDeclaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -153,7 +153,7 @@ export interface FunctionDefinition extends BaseASTNode {
 export interface EventDefinition extends BaseASTNode {
   type: 'EventDefinition';
   name: string;
-  parameters: ParameterList[];
+  parameters: ParameterList;
 }
 export interface EnumValue extends BaseASTNode {
   type: 'EnumValue';


### PR DESCRIPTION
`ParameterList` already contains, by definition, a list, so the collection type here is incorrect.